### PR TITLE
Fix page leak in watcher

### DIFF
--- a/letus_checker_secure.py
+++ b/letus_checker_secure.py
@@ -150,6 +150,7 @@ class LetusChecker:
                     alerts.append(task)
         if alerts:
             notify(alerts)
+        await page.close()
         return len(alerts)
 
 # --------------------------- CLI ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- close Playwright pages in `run` so the watcher doesn't leak browser pages

## Testing
- `python -m py_compile letus_checker_secure.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ffea684288322a176813737c7b0dc