### PR TITLE
Update LETUS checker dependencies

### DIFF
--- a/letus_checker_secure.py
+++ b/letus_checker_secure.py
@@ -14,9 +14,10 @@ LETUS Assignment Checker — Secure Edition
 Dependencies
 ------------
 ```bash
-pip install playwright asyncio‑run‑in‑process keyring python‑dotenv rich requests
+pip install playwright keyring python‑dotenv rich requests
 playwright install chromium
 ```
+Compatible with Python 3.11+ without the legacy `asyncio-run-in-process` helper.
 
 Quick start
 -----------


### PR DESCRIPTION
## Summary
- remove `asyncio-run-in-process` from dependency list
- clarify Python 3.11+ compatibility

## Testing
- `python -m py_compile letus_checker_secure.py`


------
https://chatgpt.com/codex/tasks/task_e_683fff99a4f4832295eba9fd68460b69