### PR TITLE
Add credential clearing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ keyring:
 python letus_checker_secure.py --configure --due-within 24
 ```
 
+Stored credentials can be removed later with `--clear`:
+
+```bash
+python letus_checker_secure.py --clear
+```
+
 After configuration you can simply run the checker:
 
 ```bash

--- a/tests/test_clear_credentials.py
+++ b/tests/test_clear_credentials.py
@@ -1,0 +1,47 @@
+import sys, types, importlib
+
+# Stub heavy dependencies
+for name in [
+    'requests',
+    'dotenv',
+    'rich',
+    'rich.console',
+    'rich.table',
+    'playwright',
+    'playwright.async_api',
+]:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+sys.modules['dotenv'].load_dotenv = lambda *a, **kw: None
+
+class DummyConsole:
+    def __init__(self, *a, **kw):
+        pass
+    def print(self, *a, **kw):
+        pass
+sys.modules['rich'].print = lambda *a, **kw: None
+sys.modules['rich.console'].Console = DummyConsole
+sys.modules['rich.table'].Table = type('Table', (), {})
+
+sys.modules['playwright.async_api'].async_playwright = lambda *a, **kw: None
+sys.modules['playwright.async_api'].BrowserContext = type('BrowserContext', (), {})
+
+# Prepare fake keyring module
+calls = []
+keyring = types.ModuleType('keyring')
+keyring.set_password = lambda *a, **k: None
+keyring.get_password = lambda *a, **k: None
+
+def delete_password(service, key):
+    calls.append((service, key))
+keyring.delete_password = delete_password
+sys.modules['keyring'] = keyring
+
+module = importlib.import_module('letus_checker_secure')
+
+
+def test_clear_credentials_calls_delete():
+    module.clear_credentials()
+    expected_keys = {'USERNAME', 'PASSWORD', 'LINE_TOKEN'}
+    assert {k for _, k in calls} == expected_keys


### PR DESCRIPTION
## Summary
- allow removing credentials with `--clear`
- add helper to delete stored secrets
- document `--clear` option
- test credential clearing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401af0a1448322b48754b67b2c63c4